### PR TITLE
chore(deps): fix broken chart deps and bump to latest stable

### DIFF
--- a/skaffold/helm/db-values.yaml
+++ b/skaffold/helm/db-values.yaml
@@ -2,6 +2,17 @@
 ##
 clusterDomain: <DOMAIN>
 
+## MySQL image
+## Bitnami moved free images to `bitnamilegacy` on 2025-08-28; `bitnami/mysql`
+## is no longer published publicly. The hardened images in `bitnamisecure`
+## require a paid subscription. The chart refuses to install with non-default
+## images unless `global.security.allowInsecureImages` is set.
+global:
+  security:
+    allowInsecureImages: true
+image:
+  repository: bitnamilegacy/mysql
+
 ## MySQL Authentication parameters
 ##
 auth:

--- a/skaffold/istio.yaml
+++ b/skaffold/istio.yaml
@@ -14,13 +14,13 @@ deploy:
       - name: istio-base
         createNamespace: true
         namespace: istio-system
-        remoteChart: https://istio-release.storage.googleapis.com/charts/base-1.24.1.tgz
+        remoteChart: https://istio-release.storage.googleapis.com/charts/base-1.29.2.tgz
         setValues:
           defaultRevision: default
       - name: istio-istiod
         createNamespace: true
         namespace: istio-system
-        remoteChart: https://istio-release.storage.googleapis.com/charts/istiod-1.24.1.tgz
+        remoteChart: https://istio-release.storage.googleapis.com/charts/istiod-1.29.2.tgz
         setValues:
           defaultRevision: default
           gateways:
@@ -37,7 +37,7 @@ deploy:
                 requests:
                   cpu: 10m
                   memory: 40Mi
-            tag: 1.24.1
+            tag: 1.29.2
           meshConfig:
             accessLogFile: /dev/stdout
             defaultConfig:
@@ -64,6 +64,4 @@ deploy:
       - name: istio-ingress
         createNamespace: true
         namespace: istio-ingress
-        remoteChart: https://istio-release.storage.googleapis.com/charts/gateway-1.24.1.tgz
-        setValues:
-          defaultRevision: default
+        remoteChart: https://istio-release.storage.googleapis.com/charts/gateway-1.29.2.tgz

--- a/skaffold/mysql.yaml
+++ b/skaffold/mysql.yaml
@@ -7,7 +7,7 @@ deploy:
     releases:
       - name: customers-db-mysql
         remoteChart: oci://registry-1.docker.io/bitnamicharts/mysql
-        version: 12.1.0
+        version: 12.3.5
         valuesFiles:
           - helm/db-values.yaml
         setValues:
@@ -17,7 +17,7 @@ deploy:
         wait: true
       - name: vets-db-mysql
         remoteChart: oci://registry-1.docker.io/bitnamicharts/mysql
-        version: 12.1.0
+        version: 12.3.5
         valuesFiles:
           - helm/db-values.yaml
         setValues:
@@ -27,7 +27,7 @@ deploy:
         wait: true
       - name: visits-db-mysql
         remoteChart: oci://registry-1.docker.io/bitnamicharts/mysql
-        version: 12.1.0
+        version: 12.3.5
         valuesFiles:
           - helm/db-values.yaml
         setValues:


### PR DESCRIPTION
## Changes

🐛 **Istio: fix gateway schema validation failure (1.24.1 → 1.29.2)**:
- Bumped all Istio charts (base, istiod, gateway) from 1.24.1 to 1.29.2 — chart 1.24.1 has a broken `values.schema.json` in the gateway chart where `_internal_defaults_do_not_set` is present in `values.yaml` but not declared as an allowed property, causing Helm v4's strict schema validation to reject the install
- Removed `defaultRevision: default` from the `istio-ingress` release — this value is only valid for the `base` chart and is rejected by the gateway chart's schema
- Updated `global.tag` in istiod setValues to match new chart version (1.24.1 → 1.29.2)

📦 **MySQL: fix Bitnami image policy change (12.1.0 → 12.3.5)**:
- Bitnami moved all free images from `docker.io/bitnami/*` to `docker.io/bitnamilegacy/*` on 2025-08-28; images in `bitnami/*` are no longer publicly available
- Added `image.repository: bitnamilegacy/mysql` override in db-values.yaml
- Added `global.security.allowInsecureImages: true` required by newer chart versions that enforce image origin validation
- Bumped chart from 12.1.0 to 12.3.5 (latest in the 8.4.x / MySQL 8.4 line; stays on same major to avoid app compatibility risk)